### PR TITLE
chore: add min-release-age cooldown for npx semantic-release

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age = 7


### PR DESCRIPTION
## Summary

Adds \`.npmrc\` with \`min-release-age = 7\` at the repo root.

\`release.yml\` runs \`npx --yes semantic-release\`; this ensures the cooldown applies when npm fetches the semantic-release tooling.

See https://cooldowns.dev for background on why package cooldowns reduce supply-chain risk.