### PR TITLE
fix: log changed attribute names instead of values when no user is authenticated

### DIFF
--- a/src/Traits/HasHistory.php
+++ b/src/Traits/HasHistory.php
@@ -29,7 +29,8 @@ trait HasHistory
 
             if ($changes->isNotEmpty()) {
                 if (! Auth::check()) {
-                    Log::error(sprintf('Changes where made to model %s with ID %u, but no user was authenticated. Changes: %s', get_class($model), $model->id, $changes));
+                    $attributeNames = collect($changes->get('updated')->getAttributes())->keys()->implode(', ');
+                    Log::error(sprintf('Changes were made to model %s with ID %u, but no user was authenticated. Changed attributes: %s', get_class($model), $model->id, $attributeNames));
 
                     return;
                 }
@@ -43,7 +44,8 @@ trait HasHistory
 
                 if ($changes->isNotEmpty()) {
                     if (! Auth::check()) {
-                        Log::error(sprintf('Changes where made to model %s with ID %u, but no user was authenticated. Changes: %s', get_class($model), $model->id, $changes));
+                        $attributeNames = collect($changes->get('updated')->getAttributes())->keys()->implode(', ');
+                        Log::error(sprintf('Changes were made to model %s with ID %u, but no user was authenticated. Changed attributes: %s', get_class($model), $model->id, $attributeNames));
 
                         return;
                     }

--- a/tests/Unit/HistoryTest.php
+++ b/tests/Unit/HistoryTest.php
@@ -168,7 +168,7 @@ class HistoryTest extends TestCase
 
         Log::shouldReceive('error')
             ->once()
-            ->with('Changes where made to model audunru\ModelHistory\Tests\Models\Product with ID 1, but no user was authenticated. Changes: {"original":{"description":"Old description"},"updated":{"description":"New description"}}');
+            ->with('Changes were made to model audunru\ModelHistory\Tests\Models\Product with ID 1, but no user was authenticated. Changed attributes: description');
 
         $product = Product::factory()->create([
             'description' => 'Old description',
@@ -187,7 +187,7 @@ class HistoryTest extends TestCase
 
         Log::shouldReceive('error')
             ->once()
-            ->with('Changes where made to model audunru\ModelHistory\Tests\Models\Product with ID 1, but no user was authenticated. Changes: {"original":{"deleted_at":null},"updated":{"deleted_at":"2020-01-01T00:00:00.000000Z"}}');
+            ->with('Changes were made to model audunru\ModelHistory\Tests\Models\Product with ID 1, but no user was authenticated. Changed attributes: deleted_at');
 
         $product = Product::factory()->create();
 


### PR DESCRIPTION
## Summary

- Attribute values (including passwords, tokens, and PII) were written to the error log whenever a model change occurred without an authenticated user — the full `$changes` collection was interpolated directly into the message
- Now logs only the changed attribute names, so sensitive values never reach the log sink
- Also fixes a long-standing typo: "where made" → "were made"

## Test plan

- [ ] `composer test` passes (19 tests, 43 assertions)
- [ ] `composer verify` passes (Pint + phpmd + phpunit)
- [ ] The two updated assertions in `HistoryTest.php` confirm the log message contains attribute names and not values