### PR TITLE
fix: ignore password, remember_token, and api_token in history by default

### DIFF
--- a/config/model-history.php
+++ b/config/model-history.php
@@ -17,4 +17,13 @@ return [
      * Date format used when returning the Change model as JSON
      */
     'date_format' => 'Y-m-d H:i:s',
+    /*
+     * Attribute names that are never recorded in history, regardless of each model's own $ignored
+     * list. Override in your published config to add or remove entries.
+     */
+    'default_ignored' => [
+        'password',
+        'remember_token',
+        'api_token',
+    ],
 ];

--- a/src/Traits/HasHistory.php
+++ b/src/Traits/HasHistory.php
@@ -135,8 +135,10 @@ trait HasHistory
      */
     public function getHistoryChanges(): Collection
     {
-        return collect($this->getDirty())->reject(function ($newValue, string $key) {
-            return in_array($key, $this->getIgnored());
+        $ignored = [...config('model-history.default_ignored', []), ...$this->getIgnored()];
+
+        return collect($this->getDirty())->reject(function ($newValue, string $key) use ($ignored) {
+            return in_array($key, $ignored);
         })->reduce(function (Collection $carry, $newValue, string $key) {
             $original = $carry->get('original', $this->newInstance());
             $updated = $carry->get('updated', $this->newInstance());

--- a/tests/Models/Product.php
+++ b/tests/Models/Product.php
@@ -23,6 +23,7 @@ class Product extends Model
     protected $fillable = [
         'description',
         'gross_cost',
+        'password',
         'purchased_at',
         'seller_address',
         'seller_identification',

--- a/tests/Unit/HistoryTest.php
+++ b/tests/Unit/HistoryTest.php
@@ -254,6 +254,37 @@ class HistoryTest extends TestCase
         Event::assertNotDispatched(HistoryChanged::class);
     }
 
+    public function test_it_does_not_record_change_when_only_default_ignored_field_changes()
+    {
+        Event::fake([
+            HistoryChanged::class,
+        ]);
+
+        $user = User::factory()->create();
+        $this->be($user);
+        $product = Product::factory()->create();
+
+        $product->update(['password' => 'secret']);
+
+        Event::assertNotDispatched(HistoryChanged::class);
+    }
+
+    public function test_it_records_non_sensitive_changes_but_ignores_default_ignored_fields()
+    {
+        $user = User::factory()->create();
+        $this->be($user);
+        $product = Product::factory()->create([
+            'description' => 'Old description',
+        ]);
+
+        $product->update(['description' => 'New description', 'password' => 'secret']);
+
+        $this->assertCount(1, $product->history);
+        $changes = $product->history->first()->changes;
+        $this->assertArrayHasKey('description', $changes['updated']);
+        $this->assertArrayNotHasKey('password', $changes['updated']);
+    }
+
     public function test_it_checks_that_unchanged_product_has_history_set_to_false()
     {
         $product = Product::factory()->create();

--- a/tests/database/migrations/2021_09_18_000000_create_products_table.php
+++ b/tests/database/migrations/2021_09_18_000000_create_products_table.php
@@ -23,6 +23,7 @@ class CreateProductsTable extends Migration
             $table->string('seller_address');
             $table->string('seller_phone')->nullable();
             $table->string('seller_identification')->nullable();
+            $table->string('password')->nullable();
             $table->timestamps();
             $table->softDeletes();
         });


### PR DESCRIPTION
## Summary

- `model-history` had no default deny-list for sensitive fields — a consumer adding `HasHistory` to a `User` model without calling `addIgnored(['password', ...])` would persist and expose password hashes and tokens in history records
- Introduces a `default_ignored` config key (`['password', 'remember_token', 'api_token']`) applied at the filter chokepoint in `getHistoryChanges()`, so sensitive fields are never recorded even without any per-model configuration
- The fix is applied at `getHistoryChanges()` (not the `retrieved` event hook) to also cover models that are created and updated in the same request — where `retrieved` never fires
- Consumers can override `default_ignored` in their published config; the per-model `$ignored` list is unchanged and still merged in

## Test plan

- [ ] `test_it_does_not_record_change_when_only_default_ignored_field_changes` — updating only `password` dispatches no `HistoryChanged` event
- [ ] `test_it_records_non_sensitive_changes_but_ignores_default_ignored_fields` — updating `password` + `description` records a change for `description` only, with no `password` key in the stored `changes`
- [ ] All existing tests pass unchanged (21 tests, 47 assertions)
- [ ] `composer verify` passes (Pint + phpmd + phpunit)